### PR TITLE
fix: compatibility with php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0"
+        "php": "7.4|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Since php 8.0, the `implode` function has its parameters switched: 

> Legacy signature (deprecated as of PHP 7.4.0, removed as of PHP 8.0.0):

https://www.php.net/manual/en/function.implode.php

This PR makes the library work with php 8.0+